### PR TITLE
Second test kept failing

### DIFF
--- a/learn_src/tests/messengerapp.js
+++ b/learn_src/tests/messengerapp.js
@@ -1,6 +1,8 @@
+export {}
 const assert = require("assert");
 const anchor = require("@project-serum/anchor");
 const { SystemProgram } = anchor.web3;
+var baseAccount = anchor.web3.Keypair.generate();
 
 describe("Testing our messaging app: ", () => {
   const provider = anchor.Provider.env();
@@ -8,7 +10,6 @@ describe("Testing our messaging app: ", () => {
   const program = anchor.workspace.Messengerapp;
 
   it("An account is initialized: ", async function() {
-    const baseAccount = anchor.web3.Keypair.generate();
     await program.rpc.initialize("My first message", {
       accounts: {
         baseAccount: baseAccount.publicKey,
@@ -21,11 +22,10 @@ describe("Testing our messaging app: ", () => {
     const account = await program.account.baseAccount.fetch(baseAccount.publicKey);
     console.log("Data: ", account.data);
     assert.ok(account.data === "My first message");
-    _baseAccount = baseAccount;
+    baseAccount = baseAccount;
   });
 
   it("Update the account previously created: ", async function() {
-    const baseAccount = _baseAccount;
 
     await program.rpc.update("My second message", {
       accounts: {


### PR DESCRIPTION
Why: 
The constant baseAccount on 11 was causing `_baseAccount` on line 26 to error. 

The constant baseAccount on line 11 was falling out of scope for the second test when we tried calling it -> Error 
`` ReferenceError: Cannot access 'baseAccount' before initialization``

What: 
I moved baseAccount out of the describe variable and made it its own variable so it can be accessed from anywhere within the script. 

Test: 
Try running the test case on main branch. then run mine. Mine should show no errors and all tests should pass. 